### PR TITLE
[ENT-124] Validate serial number as string to work around libxml2 limitation

### DIFF
--- a/lib/schemas/xmldsig-core-schema.xsd
+++ b/lib/schemas/xmldsig-core-schema.xsd
@@ -188,7 +188,7 @@
 <complexType name="X509IssuerSerialType"> 
   <sequence> 
     <element name="X509IssuerName" type="string"/> 
-    <element name="X509SerialNumber" type="integer"/> 
+    <element name="X509SerialNumber" type="string"/>
   </sequence>
 </complexType>
 


### PR DESCRIPTION
I've submitted this upstream as well, but I'm not sure whether they'll accept it. In the mean time we can change Web's Gemfile to pull this branch from our fork. See the background in https://pagerduty.atlassian.net/browse/ENT-124 for explanation.

This has been tested between ADFS 2016 (in AWS) and pdt-irving-test.cloudoverflow.com (PD load_test)